### PR TITLE
Add support for Jazzy and Lyrical distros

### DIFF
--- a/.devcontainer/compose.devcontainer.wsl2.yml
+++ b/.devcontainer/compose.devcontainer.wsl2.yml
@@ -1,0 +1,18 @@
+services:
+  dev:
+    volumes:
+      # X11 socket for GUI forwarding
+      - /tmp/.X11-unix:/tmp/.X11-unix:rw
+      # X authority for X11 authentication
+      - ${XAUTHORITY:-$HOME/.Xauthority}:/tmp/.Xauthority:ro
+      # WSL2 GUI support
+      - /mnt/wslg:/mnt/wslg:ro
+
+    environment:
+      - QT_X11_NO_MITSHM=1
+      - XAUTHORITY=/tmp/.Xauthority
+      - DISPLAY=${DISPLAY:-:0}
+      - LIBGL_ALWAYS_SOFTWARE=1
+      - WAYLAND_DISPLAY=${WAYLAND_DISPLAY:-wayland-0}
+      # - XDG_RUNTIME_DIR=${XDG_RUNTIME_DIR:-/run/user/1000}
+      - PULSE_SERVER=${PULSE_SERVER:-/mnt/wslg/PulseServer}

--- a/.devcontainer/compose.devcontainer.yml
+++ b/.devcontainer/compose.devcontainer.yml
@@ -1,36 +1,31 @@
 services:
   dev:
+    env_file: .env
+
     build:
-      context: ..
+      context: .
       dockerfile: docker/Dockerfile
       target: dev
       args:
-        ROS_DISTRO: ${ROS_DISTRO:-humble}
-    image: adi_ros2:${ROS_DISTRO:-humble}-dev
+        ROS_DISTRO: ${ROS_DISTRO}
+    image: adi_ros2:${ROS_DISTRO}-dev
 
     volumes:
-      - ..:/adi_ros2_ws:cached
-      # X11 socket for GUI forwarding
-      - /tmp/.X11-unix:/tmp/.X11-unix:rw
-      # X authority for X11 authentication
-      - ${XAUTHORITY:-$HOME/.Xauthority}:/tmp/.Xauthority:ro
+      # Mount the workspace into the container
+      - .:/adi_ros2_ws:cached
+      # HW Access
+      - /dev:/dev
 
     # Network & IPC
     network_mode: host
     ipc: host
+    pid: host
 
     # Hardware access (Narrow this down to specific devices if your security policy requires it)
     privileged: true
+    group_add:
+      - dialout # For USB serial access
 
     # Interactivity
     stdin_open: true
     tty: true
-
-    # Environment
-    environment:
-      - QT_X11_NO_MITSHM=1
-      - XAUTHORITY=/tmp/.Xauthority
-      - ROS_DOMAIN_ID=${ROS_DOMAIN_ID:-0}
-      - ROS_DISTRO=${ROS_DISTRO:-humble}
-      - DISPLAY=${DISPLAY:-:0}
-

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,27 +1,38 @@
 {
-  "name": "ADI ROS2 (Dev)",
+  "name": "ADI ROS2 (dev)",
   "dockerComposeFile": [
+    // Keep compose.yml first to force build context to be the root of the repo
+    "../compose.yml",
     "./compose.devcontainer.yml",
+    "./compose.devcontainer.wsl2.yml"
+    // "./docker-compose.override.yml"
   ],
   "service": "dev",
+  "runServices": [
+    "dev"
+  ],
   "workspaceFolder": "/adi_ros2_ws",
   "customizations": {
     "vscode": {
       "extensions": [
-        "ms-iot.vscode-ros",
-        "ms-vscode.cpptools",
+        "Ranch-Hand-Robotics.rde-ros-2",
+        "Ranch-Hand-Robotics.urdf-editor",
         "ms-vscode.cpptools-extension-pack",
-        "ms-vscode.cmake-tools",
-        "twxs.cmake",
         "ms-python.python",
-        "streetsidesoftware.code-spell-checker"
-      ],
-      "settings": {
-        "ros.distro": "humble",
-        "cmake.configureOnOpen": false
-      }
+        "ms-python.vscode-pylance",
+        "mhutchie.git-graph",
+        "ms-vscode.cmake-tools",
+        "docker.docker",
+        "ms-azuretools.vscode-docker",
+        "ms-vscode.cpptools",
+        "ms-python.isort",
+        "Ranch-Hand-Robotics.rde-pack",
+        "ms-python.black-formatter",
+        "KylinIdeTeam.cmake-intellisence"
+      ]
     }
   },
   "remoteUser": "root",
-  "shutdownAction": "stopCompose"
+  "shutdownAction": "stopCompose",
+  "postCreateCommand": "bash /adi_ros2_ws/.devcontainer/postCreateCommand.sh"
 }

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -eou pipefail
+
+sudo apt update
+
+if command -v rosdep >/dev/null 2>&1; then
+  rosdep update --rosdistro "${ROS_DISTRO}"
+fi
+
+if ! colcon mixin list 2>/dev/null | grep -q '^default:'; then
+  default_mixin_url="https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml"
+  colcon mixin add default "${default_mixin_url}"
+fi
+colcon mixin update default
+
+cd /adi_ros2_ws
+rosdep install --from-paths src --ignore-src -r -y
+
+# adi_imu dependency for RVIZ simulation
+sudo apt-get install -y ros-${ROS_DISTRO}-imu-tools
+
+# Automatically source build environment in new shells
+echo "[ -f /adi_ros2_ws/install/setup.bash ] && source /adi_ros2_ws/install/setup.bash" >> /etc/bash.bashrc

--- a/.env
+++ b/.env
@@ -1,14 +1,17 @@
-# Override on the command line: ROS_DISTRO=jazzy docker compose ...
+# NOTE: this file provides default values for environment variables used by the `docker compose` command.
+# You can override defaults on the command line:
+#     ROS_DISTRO=jazzy docker compose ...
 
-ROS_DISTRO=humble
+ROS_DISTRO=lyrical
 
 # Nvidia L4T Version
 L4T_VERSION=r36.2.0
 
-# Target architecture for cross-compilation.
-# Leave unset to build for the host architecture (most common case).
-# Set to arm64 when cross-compiling for Jetson or other ARM64 targets.
-# TARGETARCH=arm64
+# Service command config:
 
-# ROS domain ID — isolates ROS2 communication between robot setups on the same network.
-ROS_DOMAIN_ID=0
+# Service: adi_iio
+ADI_IIO_URI="ip:192.168.2.1"
+
+# Service: adi_imu
+ADI_IMU_URI="ip:10.87.54.122"
+ADI_IMU_DEVICE_NAME="adis16545-3"

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-# This file contains code owners for the imu-ros2 project
+# This file contains code owners for the adi_ros2 project
 
 # The following are the global code owners which will be responsible for all
 # files in the repository.

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,15 +2,11 @@ name: Dockerfiles
 on:
   push:
     branches:
-      - "**humble**"
-      # - "**jazzy**"
-      # - "**rolling**"
-      - "**ci**"
+      - main
+      - develop-*
+      - ci-*
   pull_request:
   workflow_dispatch:
-
-env:
-  ROS_DISTRO: humble
 
 permissions:
   contents: read
@@ -41,32 +37,39 @@ jobs:
   build:
     runs-on: ${{ matrix.runner }}
     needs: lint
+    env:
+      ROS_DISTRO: ${{ matrix.ros_distro }}
     strategy:
       fail-fast: false
       matrix:
+        ros_distro: [humble, jazzy, lyrical]
+        track: [amd64, arm64, l4t]
         include:
-          - arch: amd64
+          - track: amd64
             runner: ubuntu-latest
-            targets: core,base,full,desktop
+            targets: core,base
             image-prefix: adi_ros2
-            artifact: images-amd64
-          - arch: arm64
-            runner: ubuntu-24.04-arm
-            targets: core,base,full,desktop
+          - track: arm64
+            runner: ubuntu-26.04-arm
+            targets: core,base
             image-prefix: adi_ros2
-            artifact: images-arm64
-          - arch: arm64
-            runner: ubuntu-24.04-arm
-            targets: l4t-core,l4t-base,l4t-full,l4t-desktop
+          - track: l4t
+            runner: ubuntu-26.04-arm
+            targets: l4t-core,l4t-base
             image-prefix: adi_ros2-l4t
-            artifact: images-l4t
+        exclude:
+          # The L4T base image (nvcr.io/nvidia/l4t-base, JetPack 6) is Ubuntu
+          # 22.04, so only ros-humble-* apt packages exist for it.
+          # jazzy/lyrical require Ubuntu 24.04/26.04 and cannot be built on this base.
+          - { track: l4t, ros_distro: jazzy }
+          - { track: l4t, ros_distro: lyrical }
     steps:
       - uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build all stages (${{ matrix.arch }})
+      - name: Build all stages (${{ matrix.ros_distro }} / ${{ matrix.track }})
         uses: docker/bake-action@v7
         with:
           source: .
@@ -79,15 +82,13 @@ jobs:
           docker save \
             ${{ matrix.image-prefix }}:${{ env.ROS_DISTRO }}-core \
             ${{ matrix.image-prefix }}:${{ env.ROS_DISTRO }}-base \
-            ${{ matrix.image-prefix }}:${{ env.ROS_DISTRO }}-full \
-            ${{ matrix.image-prefix }}:${{ env.ROS_DISTRO }}-desktop \
-          | zstd -T0 -3 > "${{ runner.temp }}/${{ matrix.artifact }}.tar.zst"
+          | zstd -T0 -3 > "${{ runner.temp }}/images-${{ matrix.ros_distro }}-${{ matrix.track }}.tar.zst"
 
       - name: Upload images
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.artifact }}
-          path: ${{ runner.temp }}/${{ matrix.artifact }}.tar.zst
+          name: images-${{ matrix.ros_distro }}-${{ matrix.track }}
+          path: ${{ runner.temp }}/images-${{ matrix.ros_distro }}-${{ matrix.track }}.tar.zst
           retention-days: 1
 
   scan:
@@ -96,32 +97,33 @@ jobs:
     permissions:
       contents: read
       security-events: write
+    env:
+      ROS_DISTRO: ${{ matrix.ros_distro }}
     strategy:
       fail-fast: false
       matrix:
+        ros_distro: [humble, jazzy, lyrical]
         arch: [amd64, arm64, l4t]
-        stage: [core, base, full, desktop]
+        stage: [core, base]
         include:
-          - arch: amd64
-            artifact: images-amd64
-            image-prefix: adi_ros2
-          - arch: arm64
-            artifact: images-arm64
-            image-prefix: adi_ros2
-          - arch: l4t
-            artifact: images-l4t
-            image-prefix: adi_ros2-l4t
+          - { arch: amd64, image-prefix: adi_ros2 }
+          - { arch: arm64, image-prefix: adi_ros2 }
+          - { arch: l4t,   image-prefix: adi_ros2-l4t }
+        exclude:
+          # No L4T images are built for jazzy/lyrical (see build job).
+          - { arch: l4t, ros_distro: jazzy }
+          - { arch: l4t, ros_distro: lyrical }
     steps:
       - uses: actions/checkout@v4
 
       - name: Download images
         uses: actions/download-artifact@v4
         with:
-          name: ${{ matrix.artifact }}
+          name: images-${{ matrix.ros_distro }}-${{ matrix.arch }}
           path: ${{ runner.temp }}
 
       - name: Load images
-        run: zstd -d "${{ runner.temp }}/${{ matrix.artifact }}.tar.zst" --stdout | docker load
+        run: zstd -d "${{ runner.temp }}/images-${{ matrix.ros_distro }}-${{ matrix.arch }}.tar.zst" --stdout | docker load
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3
@@ -129,7 +131,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Scan CVEs — ${{ matrix.stage }} (${{ matrix.arch }})
+      - name: Scan CVEs — ${{ matrix.ros_distro }} ${{ matrix.stage }} (${{ matrix.arch }})
         id: cve-scan
         uses: docker/scout-action@v1
         continue-on-error: true
@@ -138,7 +140,7 @@ jobs:
           image: ${{ matrix.image-prefix }}:${{ env.ROS_DISTRO }}-${{ matrix.stage }}
           only-severities: critical,high
           only-fixed: true
-          sarif-file: ${{ runner.temp }}/scout-${{ matrix.arch }}-${{ matrix.stage }}.sarif
+          sarif-file: ${{ runner.temp }}/scout-${{ matrix.ros_distro }}-${{ matrix.arch }}-${{ matrix.stage }}.sarif
           summary: true
           write-comment: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -147,30 +149,30 @@ jobs:
         uses: github/codeql-action/upload-sarif@v4
         if: steps.cve-scan.outcome == 'success'
         with:
-          sarif_file: ${{ runner.temp }}/scout-${{ matrix.arch }}-${{ matrix.stage }}.sarif
+          sarif_file: ${{ runner.temp }}/scout-${{ matrix.ros_distro }}-${{ matrix.arch }}-${{ matrix.stage }}.sarif
           category: ${{ matrix.image-prefix }}-${{ env.ROS_DISTRO }}-${{ matrix.arch }}-${{ matrix.stage }}
 
       - name: Upload SARIF artifact
         uses: actions/upload-artifact@v4
         if: steps.cve-scan.outcome == 'success'
         with:
-          name: sarif-${{ matrix.arch }}-${{ matrix.stage }}
-          path: ${{ runner.temp }}/scout-${{ matrix.arch }}-${{ matrix.stage }}.sarif
+          name: sarif-${{ matrix.ros_distro }}-${{ matrix.arch }}-${{ matrix.stage }}
+          path: ${{ runner.temp }}/scout-${{ matrix.ros_distro }}-${{ matrix.arch }}-${{ matrix.stage }}.sarif
           retention-days: 30
 
-      - name: Generate SBOM — ${{ matrix.stage }} (${{ matrix.arch }})
+      - name: Generate SBOM — ${{ matrix.ros_distro }} ${{ matrix.stage }} (${{ matrix.arch }})
         uses: docker/scout-action@v1
         with:
           command: sbom
           image: ${{ matrix.image-prefix }}:${{ env.ROS_DISTRO }}-${{ matrix.stage }}
           format: spdx
-          output: ${{ runner.temp }}/sbom-${{ matrix.arch }}-${{ matrix.stage }}.spdx.json
+          output: ${{ runner.temp }}/sbom-${{ matrix.ros_distro }}-${{ matrix.arch }}-${{ matrix.stage }}.spdx.json
           summary: false
 
       - name: Upload SBOM artifact
         uses: actions/upload-artifact@v4
         with:
-          name: sbom-${{ matrix.arch }}-${{ matrix.stage }}
-          path: ${{ runner.temp }}/sbom-${{ matrix.arch }}-${{ matrix.stage }}.spdx.json
+          name: sbom-${{ matrix.ros_distro }}-${{ matrix.arch }}-${{ matrix.stage }}
+          path: ${{ runner.temp }}/sbom-${{ matrix.ros_distro }}-${{ matrix.arch }}-${{ matrix.stage }}.spdx.json
           retention-days: 30
 

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -2,14 +2,11 @@ name: Documentation
 on:
     push:
       branches:
-        - humble
+        - main
         - doc-*
       tags:
         - v*.*.*
     pull_request:
-
-env:
-  GH_TOKEN: ${{ secrets.GH_TOKEN }}
 
 jobs:
   build-doc:
@@ -20,8 +17,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         ref: ${{ github.head_ref }}
-        persist-credentials: false
-        token: ${{ env.GH_TOKEN }}
         submodules: true
 
     - name: Set up Python3 environment
@@ -51,8 +46,7 @@ jobs:
   deploy-doc:
     runs-on: ubuntu-latest
     needs: build-doc
-    # Extend the job with future ROS2 releases
-    if: github.ref == 'refs/heads/humble'
+    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/heads/doc-')
 
     steps:
     - uses: actions/checkout@v4

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,56 @@
+{
+    "version": "2.0.0",
+    "inputs": [
+        {
+            "id": "package",
+            "type": "pickString",
+            "description": "Single ROS2 package name to build",
+            "default": "adi_imu",
+            "options": [
+                "adi_iio",
+                "adi_imu"
+            ]
+        }
+    ],
+    "tasks": [
+        {
+            "label": "colcon: build package",
+            "type": "shell",
+            "command": "bash",
+            "args": [
+                "${workspaceFolder}/scripts/build.sh",
+                "${input:package}"
+            ],
+            "options": {
+                "cwd": "${workspaceFolder}"
+            },
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "presentation": {
+                "reveal": "always",
+                "panel": "shared",
+                "clear": true
+            },
+            "problemMatcher": []
+        },
+        {
+            "label": "colcon: clean artifacts",
+            "type": "shell",
+            "command": "bash",
+            "args": [
+                "${workspaceFolder}/scripts/clean.sh"
+            ],
+            "options": {
+                "cwd": "${workspaceFolder}"
+            },
+            "presentation": {
+                "reveal": "always",
+                "panel": "shared",
+                "clear": true
+            },
+            "problemMatcher": []
+        }
+    ]
+}

--- a/compose.build.yml
+++ b/compose.build.yml
@@ -9,7 +9,6 @@ services:
       target: core
       args:
         ROS_DISTRO: ${ROS_DISTRO}
-        TARGETARCH: ${TARGETARCH:-}
     image: adi_ros2:${ROS_DISTRO}-core
 
   base:
@@ -19,7 +18,6 @@ services:
       target: base
       args:
         ROS_DISTRO: ${ROS_DISTRO}
-        TARGETARCH: ${TARGETARCH:-}
     image: adi_ros2:${ROS_DISTRO}-base
 
   full:
@@ -29,7 +27,6 @@ services:
       target: full
       args:
         ROS_DISTRO: ${ROS_DISTRO}
-        TARGETARCH: ${TARGETARCH:-}
     image: adi_ros2:${ROS_DISTRO}-full
 
   desktop:
@@ -39,7 +36,6 @@ services:
       target: desktop
       args:
         ROS_DISTRO: ${ROS_DISTRO}
-        TARGETARCH: ${TARGETARCH:-}
     image: adi_ros2:${ROS_DISTRO}-desktop
 
 # Jetson/L4T Images (arm64 L4T):

--- a/compose.yml
+++ b/compose.yml
@@ -1,14 +1,29 @@
 services:
   adi_iio:
-    image: adi_ros2:${ROS_DISTRO:-humble}-core
+    image: adi_ros2:${ROS_DISTRO}-core
     container_name: adi-iio
     privileged: true
     network_mode: host
     ipc: host
-    command: ros2 run adi_iio adi_iio_node --ros-args -p uri:="ip:192.168.2.1"
+    command: >
+      ros2 run adi_iio adi_iio_node --ros-args
+        -p uri:="${ADI_IIO_URI:-ip:192.168.2.1}"
+
+  adi_imu:
+    image: adi_ros2:${ROS_DISTRO}-core
+    container_name: adi-imu
+    privileged: true
+    network_mode: host
+    ipc: host
+    command: >
+      ros2 run adi_imu adi_imu_node --ros-args
+        -p iio_context_string:="${ADI_IMU_URI:-ip:10.87.54.122}"
+        -p imu_device_name:="${ADI_IMU_DEVICE_NAME:-adis16545-3}"
+        -p measured_data_topic_selection:='2'
+        --log-level debug
 
   shell:
-    image: adi_ros2:${ROS_DISTRO:-humble}-base
+    image: adi_ros2:${ROS_DISTRO}-base
     privileged: true
     network_mode: host
     ipc: host

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -35,6 +35,11 @@ mkdir -p /tmp/pkg_debs
 
 while IFS= read -r -d '' pkg_xml; do
     pkg_dir="$(dirname "${pkg_xml}")"
+    # Skip iio_ros2 example manifests
+    if [[ "${pkg_xml}" == */examples/*/package.xml ]]; then
+        continue
+    fi
+
     pkg_name="$(grep -m1 '<name>' "${pkg_xml}" \
         | sed 's|.*<name>\(.*\)</name>.*|\1|')"
     [ -z "${pkg_name}" ] && continue
@@ -138,10 +143,13 @@ FROM ros:${ROS_DISTRO}-ros-core AS core
 
 ARG ROS_DISTRO
 ARG OVERLAY
+ARG WORKSPACE
 ARG VERSION
 
 ENV OVERLAY=${OVERLAY}
 ENV DEBIAN_FRONTEND=noninteractive
+
+WORKDIR ${WORKSPACE}
 
 # Install exec runtime dependencies
 COPY --from=cacher /tmp/pkg_debs/ALL.txt /tmp/exec_debs.txt
@@ -153,6 +161,9 @@ RUN --mount=type=cache,target=/etc/apt/apt.conf.d,from=cacher,source=/etc/apt/ap
 
 # Install Robotics SDK packages
 COPY --from=builder ${OVERLAY} ${OVERLAY}
+
+# Keep cloned workspace sources for debugging and inspection
+COPY --from=cacher ${WORKSPACE}/src ${WORKSPACE}/src
 
 # Store source VCS manifest for reference
 COPY docker/adi_ros2-${ROS_DISTRO}.yml ${OVERLAY}/adi_ros2-${ROS_DISTRO}.yml
@@ -196,10 +207,13 @@ FROM ros:${ROS_DISTRO}-ros-base AS base
 
 ARG ROS_DISTRO
 ARG OVERLAY
+ARG WORKSPACE
 ARG VERSION
 
 ENV OVERLAY=${OVERLAY}
 ENV DEBIAN_FRONTEND=noninteractive
+
+WORKDIR ${WORKSPACE}
 
 # Install exec runtime dependencies
 COPY --from=cacher /tmp/pkg_debs/ALL.txt /tmp/exec_debs.txt
@@ -211,6 +225,9 @@ RUN --mount=type=cache,target=/etc/apt/apt.conf.d,from=cacher,source=/etc/apt/ap
 
 # Install Robotics SDK packages
 COPY --from=builder ${OVERLAY} ${OVERLAY}
+
+# Keep cloned workspace sources for debugging and inspection
+COPY --from=cacher ${WORKSPACE}/src ${WORKSPACE}/src
 
 # Runtime utilities
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
@@ -324,10 +341,17 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
     apt-get update && apt-get install -y --no-install-recommends \
+      # Tools
+      tmux \
+      vim \
+      gh \
+      iputils-ping \
+      libiio-utils \
       # Build toolchain
       build-essential \
       ccache \
       cmake \
+      ninja-build \
       git \
       python3-colcon-common-extensions \
       python3-colcon-mixin \
@@ -346,7 +370,10 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
       python3-pip \
       # ROS ament linting
       ros-${ROS_DISTRO}-ament-clang-format \
-      ros-${ROS_DISTRO}-ament-cmake-clang-format
+      ros-${ROS_DISTRO}-ament-cmake-clang-format \
+      # ROS2 release package upstream
+      python3-bloom \
+      python3-catkin-pkg
 
 # Source the base ROS2 distro in interactive shells opened by devcontainer
 # (docker exec does not invoke the ENTRYPOINT, so /ros_entrypoint.sh is never run)

--- a/docker/README.md
+++ b/docker/README.md
@@ -21,6 +21,25 @@ docker run -it --rm --net=host --ipc=host --privileged adi_ros2:humble-base
 | `full`    | base + Nav2, SLAM, CANopen         |
 | `desktop` | full + RViz2, rqt                  |
 
+## Selecting a ROS2 Distribution
+
+The `ROS_DISTRO` variable (default in `.env`) selects both the ROS2 base image
+and the ADI packages compiled in, via the matching `docker/adi_ros2-<distro>.yml`
+source manifest. Override it per command or edit `.env`:
+
+```bash
+ROS_DISTRO=jazzy docker compose -f compose.build.yml build base
+```
+
+| `ROS_DISTRO` | Manifest                      |
+| ------------ | ----------------------------- |
+| `humble`     | `docker/adi_ros2-humble.yml`  |
+| `jazzy`      | `docker/adi_ros2-jazzy.yml`   |
+| `lyrical`    | `docker/adi_ros2-lyrical.yml` |
+
+A distro can only be built if its `docker/adi_ros2-<distro>.yml` manifest exists.
+To add one, create that file listing the repos and branches for the distro.
+
 ## Build Examples
 
 ```bash

--- a/docker/adi_ros2-jazzy.yml
+++ b/docker/adi_ros2-jazzy.yml
@@ -1,0 +1,9 @@
+repositories:
+  iio_ros2:
+    type: git
+    url: https://github.com/analogdevicesinc/iio_ros2.git
+    version: jazzy
+  imu_ros2:
+    type: git
+    url: https://github.com/analogdevicesinc/imu_ros2.git
+    version: jazzy

--- a/docker/adi_ros2-lyrical.yml
+++ b/docker/adi_ros2-lyrical.yml
@@ -1,0 +1,9 @@
+repositories:
+  iio_ros2:
+    type: git
+    url: https://github.com/analogdevicesinc/iio_ros2.git
+    version: lyrical
+  imu_ros2:
+    type: git
+    url: https://github.com/analogdevicesinc/imu_ros2.git
+    version: lyrical

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+package_name="${1:?Usage: bash scripts/build.sh <package>}"
+
+export MAKEFLAGS="-l1 -j1"
+
+export IIO_ROS2_ENABLE_HW_TESTS=1
+export TEST_NODE_NAME="tester"
+export TEST_URI="ip:192.168.2.1"
+export TEST_TIMEOUT="60"
+
+export IMU_ROS2_ENABLE_HW_TESTS=1
+
+colcon build --event-handlers console_direct+ \
+     --packages-up-to "${package_name}" --symlink-install --mixin \
+    ccache \
+    compile-commands \
+    rel-with-deb-info \
+    ninja

--- a/scripts/build_deb.sh
+++ b/scripts/build_deb.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+#===============================================================================
+# Build a Debian (.deb) package for a ROS2 package.
+#
+# Usage:
+#   ./scripts/build_deb.sh
+#
+# Environment variables (all optional):
+#   ROS_DISTRO   ROS2 distribution to build for   (default: jazzy)
+#   OS_NAME      Target OS for bloom               (default: ubuntu)
+#   OS_VERSION   Target OS codename for bloom      (default: noble)
+#   OUTPUT_DIR   Directory to collect artifacts in (default: <pkg>/../deb_output)
+#   SKIP_ROSDEP  If set to 1, skip rosdep install  (default: unset)
+#
+# Requirements:
+#   python3-bloom python3-rosdep fakeroot debhelper dpkg-dev
+#   A matching ROS2 environment under /opt/ros/${ROS_DISTRO}
+#===============================================================================
+set -euo pipefail
+
+ROS_DISTRO="${ROS_DISTRO:-jazzy}"
+
+# Utilities needed to build the .deb package
+required_tools=(
+    python3-bloom
+    python3-rosdep
+    fakeroot
+    debhelper
+    dpkg-dev
+)
+sudo apt update
+sudo apt install -y "${required_tools[@]}"
+
+# Resolve the package root (parent of this scripts/ directory).
+package_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+OUTPUT_DIR="${OUTPUT_DIR:-${package_dir}/../deb_output}"
+
+cd "${package_dir}"
+
+if [ ! -f package.xml ]; then
+    echo "ERROR: package.xml not found in ${package_dir}" >&2
+    exit 1
+fi
+
+echo ">> Building .deb for package in ${package_dir}"
+echo ">>   ROS_DISTRO=${ROS_DISTRO}"
+
+if [ -f "/opt/ros/${ROS_DISTRO}/setup.bash" ]; then
+    # ROS setup scripts may read unset tracing variables and are not nounset-safe.
+    set +u
+    . "/opt/ros/${ROS_DISTRO}/setup.bash"
+    set -u
+fi
+
+if [ "${SKIP_ROSDEP:-0}" != "1" ]; then
+    echo ">> Resolving dependencies with rosdep"
+    rosdep update --rosdistro "${ROS_DISTRO}" || true
+    rosdep install --from-paths . --ignore-src -y \
+        --rosdistro "${ROS_DISTRO}"
+fi
+
+echo ">> Cleaning previous packaging artifacts"
+rm -rf debian .obj-*
+
+echo ">> Generating debian/ with bloom-generate"
+bloom-generate rosdebian
+
+echo ">> Building the .deb (fakeroot debian/rules binary)"
+fakeroot debian/rules binary
+
+# 4. Collect the artifacts into OUTPUT_DIR.
+mkdir -p "${OUTPUT_DIR}"
+shopt -s nullglob
+artifacts=( "${package_dir}"/../ros-"${ROS_DISTRO}"-*.deb \
+            "${package_dir}"/../ros-"${ROS_DISTRO}"-*.ddeb )
+if [ ${#artifacts[@]} -eq 0 ]; then
+    echo "ERROR: no .deb artifacts were produced" >&2
+    exit 1
+fi
+mv -v "${artifacts[@]}" "${OUTPUT_DIR}/"
+
+echo ">> Done. Artifacts in ${OUTPUT_DIR}:"
+ls -1 "${OUTPUT_DIR}"

--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+workspace_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+targets=(
+    "${workspace_dir}/build"
+    "${workspace_dir}/install"
+    "${workspace_dir}/log"
+)
+
+printf 'Removing:'
+printf ' %q' "${targets[@]}"
+printf '\n'
+
+rm -rf "${targets[@]}"

--- a/src/adi_ros2/doc/Getting-Started/Quick-Start.rst
+++ b/src/adi_ros2/doc/Getting-Started/Quick-Start.rst
@@ -43,7 +43,56 @@ The available stages are ``core``, ``base``, ``full``, and ``desktop``.
    includes, and image sizes.
 
 
-3. Build Your First Image
+.. _select-distro:
+
+3. Select the ROS2 Distribution
+--------------------------------------------------------------------------------
+
+Every build and run command is parameterized by the ``ROS_DISTRO`` environment
+variable. It selects **two** things at once: the ROS2 base image the image is
+built ``FROM``, and the set of ADI packages compiled into it (via the matching
+``docker/adi_ros2-<distro>.yml`` source manifest).
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 32 48
+
+   * - ``ROS_DISTRO``
+     - Source manifest
+     - Packages included
+   * - ``humble``
+     - ``docker/adi_ros2-humble.yml``
+     - Full SDK — IIO, IMU, TMC motor control, 3D ToF, and dependencies
+   * - ``jazzy``
+     - ``docker/adi_ros2-jazzy.yml``
+     - ``adi_iio`` + ``adi_imu``
+   * - ``lyrical``
+     - ``docker/adi_ros2-lyrical.yml``
+     - ``adi_iio`` + ``adi_imu``
+
+The default value is defined in the repository ``.env`` file. Override it for a
+single command:
+
+.. code-block:: bash
+
+    ROS_DISTRO=jazzy docker compose -f compose.build.yml build base
+
+Or edit ``.env`` to change the default for every command:
+
+.. code-block:: bash
+
+    ROS_DISTRO=jazzy
+
+.. note::
+
+   A distribution can only be selected if a matching
+   ``docker/adi_ros2-<distro>.yml`` manifest exists — the build copies this file
+   by name. The package set differs per distribution because not every ADI
+   package has been ported to every ROS2 release. See :ref:`packages` for the
+   per-distribution package coverage and how to add a new distribution.
+
+
+4. Build Your First Image
 --------------------------------------------------------------------------------
 
 The ``docker compose`` commands use ``compose.build.yml``, which declares the
@@ -67,12 +116,13 @@ Verify the image was created:
 
     docker images | grep adi_ros2
 
-You should see ``adi_ros2`` with tag ``humble-base``.
+You should see ``adi_ros2`` tagged ``<distro>-base`` — for example
+``adi_ros2:humble-base``, or ``adi_ros2:jazzy-base`` if you selected ``jazzy``.
 
 
 .. _build-all-targets:
 
-4. Build All Targets
+5. Build All Targets
 --------------------------------------------------------------------------------
 
 From the repository root, use ``compose.build.yml`` for standard and L4T
@@ -144,7 +194,7 @@ Replace ``--target base`` with ``core``, ``full``, or ``desktop`` as needed.
    - `Build drivers and builders <https://docs.docker.com/build/builders/>`_
 
 
-5. Run a Container
+6. Run a Container
 --------------------------------------------------------------------------------
 
 Interactive Shell
@@ -152,7 +202,8 @@ Interactive Shell
 
 Start an interactive container from the ``base`` image:
 
-This command can be run from any directory after the image is built.
+This command can be run from any directory after the image is built. Use the
+tag matching the distribution you built (``humble-base`` shown here):
 
 .. code-block:: bash
 
@@ -164,7 +215,7 @@ Verify the environment is loaded:
 
     ros2 pkg list | grep adi
 
-6. Verify the Container Environment
+7. Verify the Container Environment
 --------------------------------------------------------------------------------
 
 Once inside the container shell, run the following checks:

--- a/src/adi_ros2/doc/Overview/Packages.rst
+++ b/src/adi_ros2/doc/Overview/Packages.rst
@@ -7,8 +7,15 @@ The ADI Robotics SDK includes the following ROS2 packages. Each package lives
 in its own repository and is linked here for its documentation and API reference.
 
 .. note::
-   The package manifest used during Docker builds is `docker/adi_ros2-humble.yml`.
-   This file follows the `vcstool <https://github.com/dirk-thomas/vcstool>`_
+   Docker builds use a **per-distribution** source manifest,
+   ``docker/adi_ros2-<distro>.yml`` (e.g. ``adi_ros2-humble.yml``,
+   ``adi_ros2-jazzy.yml``, ``adi_ros2-lyrical.yml``). The ``ROS_DISTRO`` build
+   variable selects which manifest is used, which is why the set of available
+   packages differs per distribution — see the **ROS2 Distros** column below.
+   Each manifest also pins every repository to a distribution-matching branch
+   or tag.
+
+   These files follow the `vcstool <https://github.com/dirk-thomas/vcstool>`_
    format and can be imported into any ROS2 workspace:
 
    .. code-block:: bash
@@ -16,8 +23,10 @@ in its own repository and is linked here for its documentation and API reference
       cd ~/ros2_ws/src
       vcs import --recursive < adi_ros2-humble.yml
 
-   You can also extend it by adding your own repositories or pinning specific
-   versions before importing.
+   You can also extend a manifest by adding your own repositories or pinning
+   specific versions before importing. To add support for a new ROS2
+   distribution, create a matching ``docker/adi_ros2-<distro>.yml`` listing the
+   repositories and branches that support it.
 
 
 Motor Controllers
@@ -70,7 +79,7 @@ IIO Sensors
      - ROS2 interface for `LibIIO`_-compatible ADI devices. Provides services to
        read and write IIO attributes, manage IIO buffers, and attach ROS2 topics
        to device channels. Compatible with any IIO-based ADI sensor.
-     - Humble |check|
+     - Humble |check| Jazzy |check| Lyrical |check|
 
 
 IMU
@@ -92,7 +101,7 @@ IMU
      - Precision MEMS IMU driver for the ADIS16xxx family. Publishes
        ``sensor_msgs/Imu`` topics from factory-calibrated gyroscopes and
        accelerometers. Supports SPI and UART interfaces.
-     - Humble |check|
+     - Humble |check| Jazzy |check| Lyrical |check|
 
    * - `adrd2121_imu_ros2`_
      - ``adrd2121_imu``

--- a/src/adi_ros2/doc/Overview/Supported-Platforms.rst
+++ b/src/adi_ros2/doc/Overview/Supported-Platforms.rst
@@ -12,6 +12,13 @@ Supported ROS2 Distributions
 --------------------------------------------------------------------------------
 
 * `ROS2 Humble Hawksbill`_ (Ubuntu 22.04 LTS)
+* `ROS2 Jazzy Jalisco`_ (Ubuntu 24.04 LTS)
+* `ROS2 Lyrical`_ (Ubuntu 26.04 LTS)
+
+The distribution is selected at build time with the ``ROS_DISTRO`` environment
+variable, which chooses both the ROS2 base image and the set of ADI packages
+compiled into the image. See :ref:`select-distro` for how to select a
+distribution and :ref:`packages` for per-distribution package coverage.
 
 
 Host Platforms
@@ -87,3 +94,5 @@ Each platform provides four image variants built as Docker multi-stage targets:
 
 
 .. _ROS2 Humble Hawksbill: https://docs.ros.org/en/humble/Releases/Release-Humble-Hawksbill.html
+.. _ROS2 Jazzy Jalisco: https://docs.ros.org/en/jazzy/Releases/Release-Jazzy-Jalisco.html
+.. _ROS2 Lyrical: https://docs.ros.org/en/lyrical/Releases/Release-Lyrical-Luth.html


### PR DESCRIPTION
- **Multi-distro Docker builds**: added `docker/adi_ros2-jazzy.yml` and `docker/adi_ros2-lyrical.yml` source manifests; `ROS_DISTRO` in `.env` is used to change the base distribution + corresponding manifest.

- **compose.yml**: define `adi_imu`, `adi_iio` and `shell` services to run nodes in a container or to interact using ROS2 CLI tools.

- **Devcontainer**: add WSL2 configuration to run GUI apps in the container.

